### PR TITLE
Fix for new js-controller behavior

### DIFF
--- a/lib/soef.js
+++ b/lib/soef.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  tools for an ioBroker Adapter v0.0.0.1
 
  Copyright (c) 2016 soef <soef@gmx.net>
@@ -678,7 +678,13 @@ function Devices (_adapter, _callback) {
                     if (!that.has(s)) that.setraw(s, {});
                     s += '.' + as[i];
                 }
-                that.setraw(id, { val: states[fullId].val });
+                
+                if (!states[fullId]){
+                  that.setraw(id, { val: null });
+                }
+                else {
+                  that.setraw(id, { val: states[fullId].val });
+                }
             }
             safeCallback(callback, 0);
         });


### PR DESCRIPTION
The new js-controller returns null in the states array for id which doesn't exists in the states db. 
This is the reason because readAllExistingObjects fails with js-controller 0.10.1.
The fix validates the existence of states[fullId].
